### PR TITLE
Add required views manage to sample server in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ var server = new Hapi.Server();
 
 server.connection({ port: 8000 });
 
+// Views manager required to handle errors
+server.views({
+    engines: {
+        html: require("handlebars")
+    },
+    relativeTo: __dirname,
+    path: "templates",
+    //helpersPath: "helpers"
+});
+
 // Register clapper with the server.
 // This example adds facebook as one of the login providers.
 server.register({ 


### PR DESCRIPTION
I'm not sure requiring views from the plugin is the way to go. I'm not even sure if it could be done in Hapi (still learning my way around the internals), but I think you'd want to throw an error that could bubble up from the plugin to the app using it. 
